### PR TITLE
Fix build error due to incorrect inclusion order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 3.4)
 
-# Convenient way to interact with The Core build system.
-include(core/build_api.cmake)
-
 # Objvious.
 project(blinky_demo)
+
+# Convenient way to interact with The Core build system.
+# Must be included after project name.
+include(core/build_api.cmake)
 
 # Our demo sources.
 add_executable(blinky main.cpp)

--- a/target.hpp
+++ b/target.hpp
@@ -15,6 +15,7 @@
 #ifndef BLINKY_DEMO_TARGET_HPP_
 #define BLINKY_DEMO_TARGET_HPP_
 
+#include <stm32f4xx.h>
 #include <stm32f4xx_gpio.h>
 #include <stm32f4xx_rcc.h>
 


### PR DESCRIPTION
With recent Nix updates compilation fails with stange 'template with C
linkage' error. Fix that too.